### PR TITLE
Update ibstat.c to remove warning

### DIFF
--- a/contrib/ofed/infiniband-diags/src/ibstat.c
+++ b/contrib/ofed/infiniband-diags/src/ibstat.c
@@ -48,6 +48,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <sys/sysctl.h> // Removes sysctlbyname() warning, line 125
 
 #include <infiniband/umad.h>
 


### PR DESCRIPTION
Patch removes implicit declaration warning from `sysctlbyname`, line 125